### PR TITLE
feat(frontend): Add AI post maker

### DIFF
--- a/frontend/src/app/pages/admin/admin.component.html
+++ b/frontend/src/app/pages/admin/admin.component.html
@@ -10,11 +10,16 @@
           <span class="mx-2">></span>
           <span>Admin</span>
         </nav>
-        <div class="flex justify-between items-center">
-          <h1 class="text-3xl font-bold">Dashboard</h1>
+        <div class="flex items-right gap-2">
+            
+          <button
+            (click)="openAiPostMaker()"
+            class="bg-white text-indigo-600 px-4 py-2 rounded-lg font-semibold hover:bg-gray-100 transition">
+            AI Post Maker & Uploader
+          </button>
           <button
             (click)="createReport()"
-            class="bg-white text-indigo-600 px-6 py-2 rounded-lg font-semibold hover:bg-gray-100 transition">
+            class="bg-white text-indigo-600 px-4 py-2 rounded-lg font-semibold hover:bg-gray-100 transition">
             Create Report
           </button>
         </div>

--- a/frontend/src/app/pages/admin/admin.component.ts
+++ b/frontend/src/app/pages/admin/admin.component.ts
@@ -76,4 +76,16 @@ export class AdminComponent implements OnInit {
     console.log('Creating report...');
     // Implement report generation logic
   }
+
+  openAiPostMaker(): void {
+    const url = 'https://jofam.app.n8n.cloud/form/1c30918f-c0ca-4a86-9701-8877c81a6df8';
+    const title = 'AI Post Maker & Uploader (Shield of Athena)';
+    const width = 900;
+    const height = 700;
+    const left = (window.screenX || 0) + (window.outerWidth - width) / 2;
+    const top = (window.screenY || 0) + (window.outerHeight - height) / 2;
+    const features = `width=${width},height=${height},left=${Math.round(left)},top=${Math.round(top)},resizable=yes,scrollbars=yes,status=yes,noopener,noreferrer`;
+    const win = window.open(url, title, features);
+    if (win) win.focus();
+  }
 }


### PR DESCRIPTION
This pull request adds a new "AI Post Maker & Uploader" button to the admin dashboard, allowing admins to quickly access an external AI-powered post creation tool. The button opens the tool in a centered popup window. The layout of the dashboard header is also updated to accommodate the new button.

**Admin dashboard UI enhancements:**

* Added an "AI Post Maker & Uploader" button to the admin dashboard header, styled consistently with other buttons.
* Updated the dashboard header layout to use a right-aligned flex container with a gap between buttons.

**Functionality additions:**

* Implemented the `openAiPostMaker()` method in `AdminComponent` to open the AI post maker tool in a centered popup window with appropriate size and features. 

closes Issue #36 