### PR TITLE
fix: Enable verbose with flag in start script

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -17,7 +17,7 @@ docker-compose up -d --build db
 Write-Host "[INFO] Waiting for database to initialize..."
 Start-Sleep -Seconds 15
 
-if ($VerboseMode) {
+if ($verbose -or $v) {
     docker-compose up --build app
 } else {
     docker-compose up -d --build app


### PR DESCRIPTION
This pull request makes a small change to the conditional logic in the `start.ps1` script, improving how verbose mode is handled when starting the application. 

* The condition now checks for both `$verbose` and `$v` variables instead of `$VerboseMode`, ensuring the correct flags trigger verbose output when running `docker-compose up --build app`.